### PR TITLE
Feature/migration logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/xmidt-org/argus v0.3.11
 	github.com/xmidt-org/bascule v0.9.0
+	github.com/xmidt-org/themis v0.4.4
 	github.com/xmidt-org/webpa-common v1.11.5-0.20210120003553-3d03d7329aee
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/go-kit/kit v0.10.0
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	github.com/xmidt-org/argus v0.3.11
 	github.com/xmidt-org/bascule v0.9.0
 	github.com/xmidt-org/themis v0.4.4

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -1,0 +1,38 @@
+package ancla
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/xmidt-org/argus/chrysom"
+	"github.com/xmidt-org/argus/model"
+)
+
+type mockPushReader struct {
+	mock.Mock
+}
+
+func (m *mockPushReader) GetItems(bucket, owner string) (chrysom.Items, error) {
+	args := m.Called(bucket, owner)
+	return args.Get(0).(chrysom.Items), args.Error(1)
+}
+
+func (m *mockPushReader) Start(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockPushReader) Stop(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockPushReader) PushItem(id, bucket, owner string, item model.Item) (chrysom.PushResult, error) {
+	args := m.Called(id, bucket, owner, item)
+	return args.Get(0).(chrysom.PushResult), args.Error(1)
+}
+
+func (m *mockPushReader) RemoveItem(id, bucket string, owner string) (model.Item, error) {
+	args := m.Called(id, bucket, owner)
+	return args.Get(0).(model.Item), args.Error(0)
+}

--- a/service.go
+++ b/service.go
@@ -16,6 +16,8 @@ import (
 	"github.com/xmidt-org/themis/xlog"
 )
 
+const errFmt = "%w: %v"
+
 var (
 	errMigrationOwnerEmpty         = errors.New("owner is required when migration section is provided in config")
 	errNonSuccessPushResult        = errors.New("got a push result but was not of success type")
@@ -89,11 +91,11 @@ type service struct {
 func (s *service) Add(owner string, w Webhook) error {
 	item, err := webhookToItem(w)
 	if err != nil {
-		return fmt.Errorf("%w: %v", errFailedWebhookConversion, err)
+		return fmt.Errorf(errFmt, errFailedWebhookConversion, err)
 	}
 	result, err := s.argus.PushItem(item.ID, s.config.Bucket, owner, item)
 	if err != nil {
-		return fmt.Errorf("%w: %v", errFailedWebhookPush, err)
+		return fmt.Errorf(errFmt, errFailedWebhookPush, err)
 	}
 
 	if result == chrysom.CreatedPushResult || result == chrysom.UpdatedPushResult {
@@ -116,19 +118,19 @@ func (s *service) AllWebhooks(owner string) ([]Webhook, error) {
 	if s.config.Migration != nil {
 		err := s.captureMigratedWebhooks(webhookSet)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", errFailedMigratedWebhooksFetch, err)
+			return nil, fmt.Errorf(errFmt, errFailedMigratedWebhooksFetch, err)
 		}
 	}
 
 	items, err := s.argus.GetItems(s.config.Bucket, owner)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", errFailedWebhooksFetch, err)
+		return nil, fmt.Errorf(errFmt, errFailedWebhooksFetch, err)
 	}
 
 	for _, item := range items {
 		webhook, err := itemToWebhook(item)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", errFailedItemConversion, err)
+			return nil, fmt.Errorf(errFmt, errFailedItemConversion, err)
 		}
 		webhookSet[item.ID] = webhook
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -51,6 +51,15 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 
+func TestAdd(t *testing.T) {
+	//TODO:
+}
+
+// Test AllWebhooks
+func TestAllWebhooks(t *testing.T) {
+	//TODO:
+}
+
 func getIncompleteButValidConfig() validateTestconfig {
 	return validateTestconfig{
 		input: &Config{
@@ -96,13 +105,4 @@ func getInvalidConfig() validateTestconfig {
 			},
 		},
 	}
-}
-
-func TestAdd(t *testing.T) {
-	//TODO:
-}
-
-// Test AllWebhooks
-func TestAllWebhooks(t *testing.T) {
-	//TODO:
 }

--- a/service_test.go
+++ b/service_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics/provider"
@@ -11,6 +12,38 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/xmidt-org/argus/chrysom"
 	"github.com/xmidt-org/argus/store"
+)
+
+var (
+	refTime              = getRefTime()
+	migrationWebhookZero = Webhook{
+		Address: "http://webhook-requester-to-sns.example",
+		Config: WebhookConfig{
+			URL: "http://events-webhook0-here.example",
+		},
+		Until: refTime,
+	}
+	migrationWebhookTwo = Webhook{
+		Address: "http://webhook-requester-to-sns.example",
+		Config: WebhookConfig{
+			URL: "http://events-webhook2-here.example",
+		},
+		Until: refTime.Add(8 * time.Second),
+	}
+	webhookZero = Webhook{
+		Address: "http://webhook-requester-to-argus.example",
+		Config: WebhookConfig{
+			URL: "http://events-webhook0-here.example",
+		},
+		Until: refTime.Add(5 * time.Second),
+	}
+	webhookOne = Webhook{
+		Address: "http://webhook-requester-to-argus.example",
+		Config: WebhookConfig{
+			URL: "http://events-webhook1-here.example",
+		},
+		Until: refTime.Add(10 * time.Second),
+	}
 )
 
 type validateTestconfig struct {
@@ -117,9 +150,132 @@ func TestAdd(t *testing.T) {
 	}
 }
 
-// Test AllWebhooks
 func TestAllWebhooks(t *testing.T) {
-	//TODO:
+	type getItemsMockResp struct {
+		Items chrysom.Items
+		Err   error
+	}
+
+	type testCase struct {
+		Description          string
+		Owner                string
+		CaptureMigratedItems bool
+		CaptureItems         bool
+		MigrationItemsResp   getItemsMockResp
+		ItemsResp            getItemsMockResp
+		ExpectedWebhooks     []Webhook
+		ExpectedErr          error
+	}
+
+	migrationItemsResp := getItemsMockResp{
+		Items: getTestMigrationItems(),
+	}
+
+	itemsResp := getItemsMockResp{
+		Items: getTestItems(),
+	}
+
+	tcs := []testCase{
+		{
+			Description:          "Fetching migrated webhooks fails",
+			Owner:                "Owner",
+			CaptureMigratedItems: true,
+			CaptureItems:         false,
+			MigrationItemsResp: getItemsMockResp{
+				Err: errors.New("db failed"),
+			},
+			ItemsResp:   itemsResp,
+			ExpectedErr: errFailedMigratedWebhooksFetch,
+		},
+
+		{
+			Description:          "Fetching argus webhooks fails",
+			Owner:                "Owner",
+			CaptureMigratedItems: true,
+			CaptureItems:         true,
+			MigrationItemsResp:   migrationItemsResp,
+			ItemsResp: getItemsMockResp{
+				Err: errors.New("db failed"),
+			},
+			ExpectedErr: errFailedWebhooksFetch,
+		},
+		{
+			Description:          "Migration capture disabled. Webhooks fetch success",
+			Owner:                "Owner",
+			CaptureMigratedItems: false,
+			CaptureItems:         true,
+			MigrationItemsResp:   migrationItemsResp,
+			ItemsResp:            itemsResp,
+			ExpectedWebhooks:     getWebhooksFromArgusOnly(),
+		},
+		{
+			Description:          "Only Migrated webhooks",
+			Owner:                "Owner",
+			CaptureMigratedItems: true,
+			CaptureItems:         true,
+			MigrationItemsResp:   migrationItemsResp,
+			ItemsResp: getItemsMockResp{
+				Items: chrysom.Items{},
+			},
+			ExpectedWebhooks: getWebhooksFromMigrationOnly(),
+		},
+		{
+			Description:          "Success fetch from both sources",
+			Owner:                "Owner",
+			CaptureMigratedItems: true,
+			CaptureItems:         true,
+			MigrationItemsResp:   migrationItemsResp,
+			ItemsResp:            itemsResp,
+			ExpectedWebhooks:     getWebhooksFromMixedSources(),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.Description, func(t *testing.T) {
+			assert := assert.New(t)
+			m := new(mockPushReader)
+			migrationCfg := &MigrationConfig{
+				Bucket: "webhooks",
+				Owner:  "migration-owner",
+			}
+			cfg := Config{}
+			if tc.CaptureMigratedItems {
+				cfg.Migration = migrationCfg
+			}
+
+			svc := service{
+				argus:  m,
+				logger: log.NewNopLogger(),
+				config: cfg,
+			}
+			if tc.CaptureMigratedItems {
+				m.On("GetItems", migrationCfg.Bucket, migrationCfg.Owner).
+					Return(tc.MigrationItemsResp.Items, tc.MigrationItemsResp.Err)
+			}
+
+			if tc.CaptureItems {
+				m.On("GetItems", svc.config.Bucket, tc.Owner).Return(tc.ItemsResp.Items, tc.ItemsResp.Err)
+			}
+
+			webhooks, err := svc.AllWebhooks(tc.Owner)
+
+			if tc.ExpectedErr != nil {
+				assert.True(errors.Is(err, tc.ExpectedErr))
+				assert.Empty(webhooks)
+			} else {
+				assert.EqualValues(tc.ExpectedWebhooks, webhooks)
+			}
+
+			if !tc.CaptureMigratedItems {
+				m.AssertNotCalled(t, "GetItems", migrationCfg.Bucket, migrationCfg.Owner)
+			}
+
+			if !tc.CaptureItems {
+				m.AssertNotCalled(t, "GetItems", svc.config.Bucket, tc.Owner)
+			}
+
+			m.AssertExpectations(t)
+		})
+	}
 }
 
 func getIncompleteButValidConfig() validateTestconfig {
@@ -167,4 +323,74 @@ func getInvalidConfig() validateTestconfig {
 			},
 		},
 	}
+}
+
+func getTestItems() chrysom.Items {
+	return chrysom.Items{
+		{
+			ID: "d73ec0f8e6137f50284453bf1da67f94659fae70cefef8745a94a638bab41b90",
+			Data: map[string]interface{}{
+				"registered_from_address": "http://webhook-requester-to-argus.example",
+				"config": map[string]interface{}{
+					"url": "http://events-webhook0-here.example",
+				},
+				"until": "2021-01-02T15:04:05Z",
+			},
+		},
+		{
+			ID: "900018a2bd769407338e49693d5e8dc91301a10620b79b3e5bffdc8791e43bc6",
+			Data: map[string]interface{}{
+				"registered_from_address": "http://webhook-requester-to-argus.example",
+				"config": map[string]interface{}{
+					"url": "http://events-webhook1-here.example",
+				},
+				"until": "2021-01-02T15:04:10Z",
+			},
+		},
+	}
+}
+
+func getTestMigrationItems() chrysom.Items {
+	return chrysom.Items{
+		{
+			ID: "d73ec0f8e6137f50284453bf1da67f94659fae70cefef8745a94a638bab41b90",
+			Data: map[string]interface{}{
+				"registered_from_address": "http://webhook-requester-to-sns.example",
+				"config": map[string]interface{}{
+					"url": "http://events-webhook0-here.example",
+				},
+				"until": "2021-01-02T15:04:00Z",
+			},
+		},
+		{
+			ID: "4f4908c2d545216b8996a701866ce1c0312bec2bf316e4cfecf2465634bf8398",
+			Data: map[string]interface{}{
+				"registered_from_address": "http://webhook-requester-to-sns.example",
+				"config": map[string]interface{}{
+					"url": "http://events-webhook2-here.example",
+				},
+				"until": "2021-01-02T15:04:08Z",
+			},
+		},
+	}
+}
+
+func getWebhooksFromArgusOnly() []Webhook {
+	return []Webhook{webhookZero, webhookOne}
+}
+
+func getWebhooksFromMigrationOnly() []Webhook {
+	return []Webhook{migrationWebhookZero, migrationWebhookTwo}
+}
+
+func getWebhooksFromMixedSources() []Webhook {
+	return []Webhook{webhookZero, webhookOne, migrationWebhookTwo}
+}
+
+func getRefTime() time.Time {
+	refTime, err := time.Parse(time.RFC3339, "2021-01-02T15:04:00Z")
+	if err != nil {
+		panic(err)
+	}
+	return refTime
 }

--- a/service_test.go
+++ b/service_test.go
@@ -1,0 +1,108 @@
+package ancla
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/metrics/provider"
+	"github.com/stretchr/testify/assert"
+)
+
+type validateTestconfig struct {
+	input    *Config
+	expected *Config
+}
+
+func TestValidateConfig(t *testing.T) {
+	type testCase struct {
+		Description string
+		Data        validateTestconfig
+		ExpectedErr error
+	}
+
+	tcs := []testCase{
+		{
+			Description: "Migration config provided without an item owner",
+			Data:        getInvalidConfig(),
+			ExpectedErr: errMigrationOwnerEmpty,
+		},
+		{
+			Description: "Incomplete but valid config",
+			Data:        getIncompleteButValidConfig(),
+		},
+		{
+			Description: "No migration section but still valid",
+			Data:        getNoMigrationValidConfig(),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Description, func(t *testing.T) {
+			assert := assert.New(t)
+			err := validateConfig(tc.Data.input)
+			if tc.ExpectedErr != nil {
+				assert.Equal(tc.ExpectedErr, err)
+			} else {
+				assert.Nil(err)
+				assert.EqualValues(tc.Data.expected, tc.Data.input)
+			}
+		})
+	}
+}
+
+func getIncompleteButValidConfig() validateTestconfig {
+	return validateTestconfig{
+		input: &Config{
+			Migration: &MigrationConfig{
+				Owner: "owner-provided",
+			},
+		},
+		expected: &Config{
+			Bucket: "webhooks",
+			Migration: &MigrationConfig{
+				Owner:  "owner-provided",
+				Bucket: "webhooks",
+			},
+			Logger:          log.NewNopLogger(),
+			MetricsProvider: provider.NewDiscardProvider(),
+		},
+	}
+}
+
+func getNoMigrationValidConfig() validateTestconfig {
+	logger := log.NewJSONLogger(ioutil.Discard)
+	metricsProvider := provider.NewExpvarProvider()
+
+	return validateTestconfig{
+		input: &Config{
+			Bucket:          "myBucket",
+			Logger:          logger,
+			MetricsProvider: metricsProvider,
+		},
+		expected: &Config{
+			Bucket:          "myBucket",
+			Logger:          logger,
+			MetricsProvider: metricsProvider,
+		},
+	}
+}
+
+func getInvalidConfig() validateTestconfig {
+	return validateTestconfig{
+		input: &Config{
+			Migration: &MigrationConfig{
+				Bucket: "myBucket",
+			},
+		},
+	}
+}
+
+func TestAdd(t *testing.T) {
+	//TODO:
+}
+
+// Test AllWebhooks
+func TestAllWebhooks(t *testing.T) {
+	//TODO:
+}

--- a/webhook.go
+++ b/webhook.go
@@ -4,26 +4,29 @@ import (
 	"time"
 )
 
+// WebhookConfig is a Webhook substructure with data related to event delivery.
+type WebhookConfig struct {
+	// URL is the HTTP URL to deliver messages to.
+	URL string `json:"url"`
+
+	// ContentType is content type value to set WRP messages to (unless already specified in the WRP).
+	ContentType string `json:"content_type"`
+
+	// Secret is the string value for the SHA1 HMAC.
+	// (Optional, set to "" to disable behavior).
+	Secret string `json:"secret,omitempty"`
+
+	// AlternativeURLs is a list of explicit URLs that should be round robin through on failure cases to the main URL.
+	AlternativeURLs []string `json:"alt_urls,omitempty"`
+}
+
 // Webhook contains all the information needed to serve events to webhook listeners.
 type Webhook struct {
 	// Address is the subscription request origin HTTP Address.
 	Address string `json:"registered_from_address"`
 
 	// Config contains data to inform how events are delivered.
-	Config struct {
-		// URL is the HTTP URL to deliver messages to.
-		URL string `json:"url"`
-
-		// ContentType is content type value to set WRP messages to (unless already specified in the WRP).
-		ContentType string `json:"content_type"`
-
-		// Secret is the string value for the SHA1 HMAC.
-		// (Optional, set to "" to disable behavior).
-		Secret string `json:"secret,omitempty"`
-
-		// AlternativeURLs is a list of explicit URLs that should be round robin through on failure cases to the main URL.
-		AlternativeURLs []string `json:"alt_urls,omitempty"`
-	} `json:"config"`
+	Config WebhookConfig `json:"config"`
 
 	// FailureURL is the URL used to notify subscribers when they've been cut off due to event overflow.
 	// Optional, set to "" to disable notifications.


### PR DESCRIPTION
**Main change introduced in this PR:**
Capturing webhook items migrated by Hecate from SNS to Argus.

**Minor changes:**
- Remove group loggers.
- Log errors when converting items to webhooks
- Don't return partial data: when an item (from among many) fails to convert into a webhook, the whole getAll operation should fail unless we advertise GetAll to be a best effort operation. 