### PR TITLE
Feature/jwt acquire parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- Support acquiring JWT token from Themis. [#59](https://github.com/xmidt-org/ancla/pull/59)
 
 ## [v0.1.5]
 - Update Argus version with request context bugfix. [#55](https://github.com/xmidt-org/ancla/pull/55)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/xmidt-org/ancla
 go 1.15
 
 require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-kit/kit v0.10.0
+	github.com/spf13/cast v1.3.1
 	github.com/stretchr/testify v1.7.0
 	github.com/xmidt-org/argus v0.3.16
 	github.com/xmidt-org/bascule v0.9.1-0.20210506212507-4df8762472bc

--- a/jwtAcquireParser.go
+++ b/jwtAcquireParser.go
@@ -27,11 +27,7 @@ type jwtAcquireParser struct {
 }
 
 func rawTokenParser(data []byte) (string, error) {
-	token, err := jwt.Parse(string(data), nil)
-	if err != nil {
-		return "", err
-	}
-	return token.Raw, nil
+	return string(data), nil
 }
 
 func rawTokenExpirationParser(data []byte) (time.Time, error) {

--- a/jwtAcquireParser.go
+++ b/jwtAcquireParser.go
@@ -62,14 +62,10 @@ func newJWTAcquireParser(pType jwtAcquireParserType) (jwtAcquireParser, error) {
 	parser := jwtAcquireParser{}
 	if pType == simpleType {
 		parser.token = acquire.DefaultTokenParser
-	} else {
-		parser.token = rawTokenParser
-	}
-
-	if pType == simpleType {
 		parser.expiration = acquire.DefaultExpirationParser
-	} else {
-		parser.expiration = rawTokenExpirationParser
+		return parser, nil
 	}
+	parser.token = rawTokenParser
+	parser.expiration = rawTokenExpirationParser
 	return parser, nil
 }

--- a/jwtAcquireParser.go
+++ b/jwtAcquireParser.go
@@ -59,13 +59,15 @@ func newJWTAcquireParser(pType jwtAcquireParserType) (jwtAcquireParser, error) {
 	if pType != simpleType && pType != rawType {
 		return jwtAcquireParser{}, errors.New("only 'simple' or 'raw' are supported as jwt acquire parser types")
 	}
-	parser := jwtAcquireParser{}
-	if pType == simpleType {
-		parser.token = acquire.DefaultTokenParser
-		parser.expiration = acquire.DefaultExpirationParser
-		return parser, nil
+	// nil defaults are fine (bascule/acquire will use the simple
+	// default parsers internally).
+	var (
+		tokenParser      acquire.TokenParser
+		expirationParser acquire.ParseExpiration
+	)
+	if pType == rawType {
+		tokenParser = rawTokenParser
+		expirationParser = rawTokenExpirationParser
 	}
-	parser.token = rawTokenParser
-	parser.expiration = rawTokenExpirationParser
-	return parser, nil
+	return jwtAcquireParser{expiration: expirationParser, token: tokenParser}, nil
 }

--- a/jwtAcquireParser.go
+++ b/jwtAcquireParser.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	errMissingExpClaims  = errors.New("missing exp claim in jwt")
+	errMissingExpClaim   = errors.New("missing exp claim in jwt")
 	errUnexpectedCasting = errors.New("unexpected casting error")
 )
 
@@ -31,7 +31,8 @@ func rawTokenParser(data []byte) (string, error) {
 }
 
 func rawTokenExpirationParser(data []byte) (time.Time, error) {
-	token, err := jwt.Parse(string(data), nil)
+	p := jwt.Parser{SkipClaimsValidation: true}
+	token, _, err := p.ParseUnverified(string(data), jwt.MapClaims{})
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -41,7 +42,7 @@ func rawTokenExpirationParser(data []byte) (time.Time, error) {
 	}
 	expVal, ok := claims["exp"]
 	if !ok {
-		return time.Time{}, errMissingExpClaims
+		return time.Time{}, errMissingExpClaim
 	}
 
 	exp, err := cast.ToInt64E(expVal)

--- a/jwtAcquireParser.go
+++ b/jwtAcquireParser.go
@@ -1,0 +1,78 @@
+package ancla
+
+import (
+	"errors"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/spf13/cast"
+	"github.com/xmidt-org/bascule/acquire"
+)
+
+type jwtAcquireParserType string
+
+const (
+	simpleType jwtAcquireParserType = "simple"
+	rawType    jwtAcquireParserType = "raw"
+)
+
+var (
+	errMissingExpClaims  = errors.New("missing exp claim in jwt")
+	errUnexpectedCasting = errors.New("unexpected casting error")
+)
+
+type jwtAcquireParser struct {
+	token      acquire.TokenParser
+	expiration acquire.ParseExpiration
+}
+
+func rawTokenParser(data []byte) (string, error) {
+	token, err := jwt.Parse(string(data), nil)
+	if err != nil {
+		return "", err
+	}
+	return token.Raw, nil
+}
+
+func rawTokenExpirationParser(data []byte) (time.Time, error) {
+	token, err := jwt.Parse(string(data), nil)
+	if err != nil {
+		return time.Time{}, err
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return time.Time{}, errUnexpectedCasting
+	}
+	expVal, ok := claims["exp"]
+	if !ok {
+		return time.Time{}, errMissingExpClaims
+	}
+
+	exp, err := cast.ToInt64E(expVal)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(exp, 0), nil
+}
+
+func newJWTAcquireParser(pType jwtAcquireParserType) (jwtAcquireParser, error) {
+	if pType == "" {
+		pType = simpleType
+	}
+	if pType != simpleType && pType != rawType {
+		return jwtAcquireParser{}, errors.New("only 'simple' or 'raw' are supported as jwt acquire parser types")
+	}
+	parser := jwtAcquireParser{}
+	if pType == simpleType {
+		parser.token = acquire.DefaultTokenParser
+	} else {
+		parser.token = rawTokenParser
+	}
+
+	if pType == simpleType {
+		parser.expiration = acquire.DefaultExpirationParser
+	} else {
+		parser.expiration = rawTokenExpirationParser
+	}
+	return parser, nil
+}

--- a/jwtAcquireParser_test.go
+++ b/jwtAcquireParser_test.go
@@ -47,6 +47,16 @@ func TestNewJWTAcquireParser(t *testing.T) {
 	}
 }
 
+func TestRawTokenParser(t *testing.T) {
+	assert := assert.New(t)
+	payload := []byte("eyJhbGciOiJSUzI1NiIsImtpZCI6ImRldmVsb3BtZW50IiwidHlwIjoiSldUIn0.eyJhbGxvd2VkUmVzb3VyY2VzIjp7ImFsbG93ZWRQYXJ0bmVycyI6WyJjb21jYXN0Il19LCJhdWQiOiJYTWlEVCIsImNhcGFiaWxpdGllcyI6WyJ4MTppc3N1ZXI6dGVzdDouKjphbGwiLCJ4MTppc3N1ZXI6dWk6YWxsIl0sImV4cCI6MTYyMjE1Nzk4MSwiaWF0IjoxNjIyMDcxNTgxLCJpc3MiOiJkZXZlbG9wbWVudCIsImp0aSI6ImN4ZmkybTZDWnJjaFNoZ1Nzdi1EM3ciLCJuYmYiOjE2MjIwNzE1NjYsInBhcnRuZXItaWQiOiJjb21jYXN0Iiwic3ViIjoiY2xpZW50LXN1cHBsaWVkIiwidHJ1c3QiOjEwMDB9.7QzRWJgxGs1cEZunMOewYCnEDiq2CTDh5R5F47PYhkMVb2KxSf06PRRGN-rQSWPhhBbev1fGgu63mr3yp_VDmdVvHR2oYiKyxP2skJTSzfQmiRyLMYY5LcLn3BObyQxU8EnLhnqGIjpORW0L5Dd4QsaZmXRnkC73yGnJx4XCx0I")
+	token, err := rawTokenParser(payload)
+	assert.Equal(string(payload), token)
+	assert.Nil(err)
+}
+
 //TODO: test raw token parser
+
+func TestRawExpirationParser(t *testing.T) {}
 
 //TODO: test raw token expiration parser

--- a/jwtAcquireParser_test.go
+++ b/jwtAcquireParser_test.go
@@ -89,5 +89,3 @@ func TestRawExpirationParser(t *testing.T) {
 		}
 	}
 }
-
-//TODO: test raw token expiration parser

--- a/jwtAcquireParser_test.go
+++ b/jwtAcquireParser_test.go
@@ -1,0 +1,52 @@
+package ancla
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewJWTAcquireParser(t *testing.T) {
+	tcs := []struct {
+		Description string
+		ParserType  jwtAcquireParserType
+		ShouldFail  bool
+	}{
+		{
+			Description: "Default",
+		},
+		{
+			Description: "Invalid type",
+			ParserType:  "advanced",
+			ShouldFail:  true,
+		},
+		{
+			Description: "Simple",
+			ParserType:  simpleType,
+		},
+		{
+			Description: "Raw",
+			ParserType:  rawType,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Description, func(t *testing.T) {
+			assert := assert.New(t)
+			p, err := newJWTAcquireParser(tc.ParserType)
+			if tc.ShouldFail {
+				assert.NotNil(err)
+				assert.Nil(p.expiration)
+				assert.Nil(p.token)
+			} else {
+				assert.Nil(err)
+				assert.NotNil(p.expiration)
+				assert.NotNil(p.token)
+			}
+		})
+	}
+}
+
+//TODO: test raw token parser
+
+//TODO: test raw token expiration parser

--- a/jwtAcquireParser_test.go
+++ b/jwtAcquireParser_test.go
@@ -2,6 +2,7 @@ package ancla
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -55,8 +56,36 @@ func TestRawTokenParser(t *testing.T) {
 	assert.Nil(err)
 }
 
-//TODO: test raw token parser
+func TestRawExpirationParser(t *testing.T) {
+	tcs := []struct {
+		Description  string
+		Payload      []byte
+		ShouldFail   bool
+		ExpectedTime time.Time
+	}{
+		{
+			Description: "Not a JWT",
+			Payload:     []byte("xyz==abcNotAJWT"),
+			ShouldFail:  true,
+		},
+		{
+			Description:  "A jwt",
+			Payload:      []byte("eyJhbGciOiJSUzI1NiIsImtpZCI6ImRldmVsb3BtZW50IiwidHlwIjoiSldUIn0.eyJhbGxvd2VkUmVzb3VyY2VzIjp7ImFsbG93ZWRQYXJ0bmVycyI6WyJjb21jYXN0Il19LCJhdWQiOiJYTWlEVCIsImNhcGFiaWxpdGllcyI6WyJ4MTppc3N1ZXI6dGVzdDouKjphbGwiLCJ4MTppc3N1ZXI6dWk6YWxsIl0sImV4cCI6MTYyMjE1Nzk4MSwiaWF0IjoxNjIyMDcxNTgxLCJpc3MiOiJkZXZlbG9wbWVudCIsImp0aSI6ImN4ZmkybTZDWnJjaFNoZ1Nzdi1EM3ciLCJuYmYiOjE2MjIwNzE1NjYsInBhcnRuZXItaWQiOiJjb21jYXN0Iiwic3ViIjoiY2xpZW50LXN1cHBsaWVkIiwidHJ1c3QiOjEwMDB9.7QzRWJgxGs1cEZunMOewYCnEDiq2CTDh5R5F47PYhkMVb2KxSf06PRRGN-rQSWPhhBbev1fGgu63mr3yp_VDmdVvHR2oYiKyxP2skJTSzfQmiRyLMYY5LcLn3BObyQxU8EnLhnqGIjpORW0L5Dd4QsaZmXRnkC73yGnJx4XCx0I"),
+			ExpectedTime: time.Unix(1622157981, 0),
+		},
+	}
 
-func TestRawExpirationParser(t *testing.T) {}
+	for _, tc := range tcs {
+		assert := assert.New(t)
+		exp, err := rawTokenExpirationParser(tc.Payload)
+		if tc.ShouldFail {
+			assert.NotNil(err)
+			assert.Empty(exp)
+		} else {
+			assert.Nil(err)
+			assert.Equal(tc.ExpectedTime, exp)
+		}
+	}
+}
 
 //TODO: test raw token expiration parser

--- a/jwtAcquireParser_test.go
+++ b/jwtAcquireParser_test.go
@@ -41,8 +41,10 @@ func TestNewJWTAcquireParser(t *testing.T) {
 				assert.Nil(p.token)
 			} else {
 				assert.Nil(err)
-				assert.NotNil(p.expiration)
-				assert.NotNil(p.token)
+				if tc.ParserType == rawType {
+					assert.NotNil(p.expiration)
+					assert.NotNil(p.token)
+				}
 			}
 		})
 	}

--- a/service.go
+++ b/service.go
@@ -172,7 +172,7 @@ func validateConfig(cfg *Config) {
 // function when you are done watching for updates.
 func Initialize(cfg Config, logger func(ctx context.Context) log.Logger, watches ...Watch) (Service, func(), error) {
 	validateConfig(&cfg)
-	prepArgusConfig(cfg, watches...)
+	prepArgusConfig(&cfg, watches...)
 	argus, err := chrysom.NewClient(cfg.Argus, logger)
 	if err != nil {
 		return nil, nil, err
@@ -190,7 +190,7 @@ func Initialize(cfg Config, logger func(ctx context.Context) log.Logger, watches
 	return svc, func() { argus.Stop(context.Background()) }, nil
 }
 
-func prepArgusConfig(cfg Config, watches ...Watch) error {
+func prepArgusConfig(cfg *Config, watches ...Watch) error {
 	watches = append(watches, webhookListSizeWatch(cfg.MetricsProvider.NewGauge(WebhookListSizeGauge)))
 	cfg.Argus.Logger = cfg.Logger
 	cfg.Argus.Listen.MetricsProvider = cfg.MetricsProvider

--- a/service.go
+++ b/service.go
@@ -69,6 +69,13 @@ type Config struct {
 	// Gets passed to Argus config before initializing the client.
 	// (Optional). Defaults to a no op provider.
 	MetricsProvider provider.Provider
+
+	// JWTParserType establishes which parser type will be used by the JWT token
+	// acquirer used by Argus. Options include 'simple' and 'raw'.
+	// Simple: parser assumes token payloads have the following structure: https://github.com/xmidt-org/bascule/blob/c011b128d6b95fa8358228535c63d1945347adaa/acquire/bearer.go#L77
+	// Raw: parser assumes all of the token payload == JWT token
+	// (Optional). Defaults to 'simple'
+	JWTParserType jwtAcquireParserType
 }
 
 type service struct {
@@ -165,12 +172,7 @@ func validateConfig(cfg *Config) {
 // function when you are done watching for updates.
 func Initialize(cfg Config, logger func(ctx context.Context) log.Logger, watches ...Watch) (Service, func(), error) {
 	validateConfig(&cfg)
-	watches = append(watches, webhookListSizeWatch(cfg.MetricsProvider.NewGauge(WebhookListSizeGauge)))
-
-	cfg.Argus.Logger = cfg.Logger
-	cfg.Argus.Listen.MetricsProvider = cfg.MetricsProvider
-	cfg.Argus.Listen.Listener = createArgusListener(cfg.Logger, watches...)
-
+	prepArgusConfig(cfg, watches...)
 	argus, err := chrysom.NewClient(cfg.Argus, logger)
 	if err != nil {
 		return nil, nil, err
@@ -186,6 +188,20 @@ func Initialize(cfg Config, logger func(ctx context.Context) log.Logger, watches
 	argus.Start(context.Background())
 
 	return svc, func() { argus.Stop(context.Background()) }, nil
+}
+
+func prepArgusConfig(cfg Config, watches ...Watch) error {
+	watches = append(watches, webhookListSizeWatch(cfg.MetricsProvider.NewGauge(WebhookListSizeGauge)))
+	cfg.Argus.Logger = cfg.Logger
+	cfg.Argus.Listen.MetricsProvider = cfg.MetricsProvider
+	cfg.Argus.Listen.Listener = createArgusListener(cfg.Logger, watches...)
+	p, err := newJWTAcquireParser(cfg.JWTParserType)
+	if err != nil {
+		return err
+	}
+	cfg.Argus.Auth.JWT.GetToken = p.token
+	cfg.Argus.Auth.JWT.GetExpiration = p.expiration
+	return nil
 }
 
 func createArgusListener(logger log.Logger, watches ...Watch) chrysom.Listener {


### PR DESCRIPTION
This change should allow users of Ancla to choose the type of parser to be used by Argus when acquiring JWT tokens. For example, it should allow users to use Themis JWT tokens by selecting the `raw` parser type.