### PR TITLE
return 400 instead of 500 in transport.go

### DIFF
--- a/mocks_test.go
+++ b/mocks_test.go
@@ -2,11 +2,17 @@ package ancla
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-kit/kit/metrics"
 	"github.com/stretchr/testify/mock"
 	"github.com/xmidt-org/argus/chrysom"
 	"github.com/xmidt-org/argus/model"
+)
+
+var (
+	errReadBodyFail      = errors.New("read test error")
+	errMockValidatorFail = errors.New("validation error")
 )
 
 type mockPushReader struct {
@@ -88,4 +94,21 @@ func interfacify(vals []string) []interface{} {
 		transformed[i] = val
 	}
 	return transformed
+}
+
+type errReader struct {
+}
+
+func (e errReader) Read(p []byte) (n int, err error) {
+	return 0, errReadBodyFail
+}
+
+func (e errReader) Close() error {
+	return errors.New("close test error")
+}
+
+func mockValidator() ValidatorFunc {
+	return func(w Webhook) error {
+		return errMockValidatorFail
+	}
 }

--- a/transport.go
+++ b/transport.go
@@ -78,7 +78,7 @@ func addWebhookRequestDecoder(config transportConfig) kithttp.DecodeRequestFunc 
 	return func(c context.Context, r *http.Request) (request interface{}, err error) {
 		requestPayload, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			return nil, err
+			return nil, &erraux.Error{Err: err, Message: "bad request body", Code: http.StatusBadRequest}
 		}
 		var webhook Webhook
 
@@ -93,7 +93,7 @@ func addWebhookRequestDecoder(config transportConfig) kithttp.DecodeRequestFunc 
 
 		err = config.v.Validate(webhook)
 		if err != nil {
-			return nil, err
+			return nil, &erraux.Error{Err: err, Message: "failed webhook validation", Code: http.StatusBadRequest}
 		}
 
 		wv.setWebhookDefaults(&webhook, r.RemoteAddr)

--- a/transport.go
+++ b/transport.go
@@ -78,7 +78,7 @@ func addWebhookRequestDecoder(config transportConfig) kithttp.DecodeRequestFunc 
 	return func(c context.Context, r *http.Request) (request interface{}, err error) {
 		requestPayload, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			return nil, &erraux.Error{Err: err, Message: "bad request body", Code: http.StatusBadRequest}
+			return nil, err
 		}
 		var webhook Webhook
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -27,11 +27,11 @@ import (
 	"testing"
 	"time"
 
+	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xmidt-org/argus/store"
 	"github.com/xmidt-org/bascule"
-	"github.com/xmidt-org/httpaux/erraux"
 )
 
 func TestErrorEncoder(t *testing.T) {
@@ -159,6 +159,8 @@ func TestAddWebhookRequestDecoder(t *testing.T) {
 		ExpectedLegacyDecodingCount float64
 		ExpectedErr                 error
 		ExpectedDecodedRequest      *addWebhookRequest
+		ReadBodyFail                bool
+		Validator                   Validator
 	}
 
 	tcs := []testCase{
@@ -166,22 +168,38 @@ func TestAddWebhookRequestDecoder(t *testing.T) {
 			Description:            "Normal happy path",
 			InputPayload:           addWebhookDecoderInput(),
 			ExpectedDecodedRequest: addWebhookDecoderOutput(),
+			Validator:              Validators{},
 		},
 		{
 			Description:                 "Legacy decoding",
 			InputPayload:                addWebhookDecoderLegacyInput(),
 			ExpectedLegacyDecodingCount: 1,
 			ExpectedDecodedRequest:      addWebhookDecoderOutput(),
+			Validator:                   Validators{},
 		},
 		{
 			Description:  "Failed to JSON Unmarshal",
 			InputPayload: "{",
-			ExpectedErr:  &erraux.Error{Err: errFailedWebhookUnmarshal, Code: http.StatusBadRequest},
+			ExpectedErr:  errFailedWebhookUnmarshal,
+			Validator:    Validators{},
 		},
 		{
 			Description:  "Empty legacy case",
 			InputPayload: "[]",
-			ExpectedErr:  &erraux.Error{Err: errNoWebhooksInLegacyDecode, Code: http.StatusBadRequest},
+			ExpectedErr:  errNoWebhooksInLegacyDecode,
+			Validator:    Validators{},
+		},
+		{
+			Description:  "Webhook validation Failure",
+			InputPayload: addWebhookDecoderInput(),
+			Validator:    Validators{mockValidator()},
+			ExpectedErr:  errMockValidatorFail,
+		},
+		{
+			Description:  "Request Body Read Failure",
+			ExpectedErr:  errReadBodyFail,
+			ReadBodyFail: true,
+			Validator:    Validators{},
 		},
 	}
 
@@ -195,12 +213,14 @@ func TestAddWebhookRequestDecoder(t *testing.T) {
 				now: func() time.Time {
 					return getRefTime()
 				},
-				v: Validators{},
+				v: tc.Validator,
 			}
 			decode := addWebhookRequestDecoder(config)
 			r, err := http.NewRequest(http.MethodPost, "http://localhost:8080", bytes.NewBufferString(tc.InputPayload))
 			require.Nil(err)
-
+			if tc.ReadBodyFail {
+				r.Body = errReader{}
+			}
 			auth := bascule.Authentication{
 				Token: bascule.NewToken("jwt", "owner-from-auth", nil),
 			}
@@ -215,7 +235,13 @@ func TestAddWebhookRequestDecoder(t *testing.T) {
 
 			decodedRequest, err := decode(context.Background(), r)
 			if tc.ExpectedErr != nil {
-				assert.Equal(tc.ExpectedErr, err)
+				assert.True(errors.Is(err, tc.ExpectedErr),
+					fmt.Errorf("error [%v] doesn't contain error [%v] in its err chain",
+						err, tc.ExpectedErr))
+				var s kithttp.StatusCoder
+				isCoder := errors.As(err, &s)
+				require.True(isCoder, "error isn't StatusCoder as expected")
+				require.Equal(http.StatusBadRequest, s.StatusCode())
 			} else {
 				assert.Nil(err)
 				assert.EqualValues(tc.ExpectedDecodedRequest, decodedRequest)
@@ -229,26 +255,6 @@ func TestAddWebhookRequestDecoder(t *testing.T) {
 			counter.AssertExpectations(t)
 		})
 	}
-}
-
-func validateWebhookInput(nowSnapShot time.Time) *Webhook {
-	return &Webhook{
-		Address: "requester.example.net",
-		Config: DeliveryConfig{
-			URL: "https://deliver-here.example.net",
-		},
-		Events: []string{"online", "offline"},
-		Matcher: MetadataMatcherConfig{
-			DeviceID: []string{".*"},
-		},
-		Duration: 25 * time.Minute,
-		Until:    nowSnapShot.Add(1000 * time.Hour),
-	}
-}
-
-func validateWebhookOutput(nowSnapShot time.Time) *Webhook {
-	webhook := validateWebhookInput(nowSnapShot)
-	return webhook
 }
 
 func addWebhookDecoderInput() string {
@@ -398,9 +404,6 @@ func encodeGetAllOutput() string {
 }
 
 func TestSetWebhookDefaults(t *testing.T) {
-	var mockNow func() time.Time = func() time.Time {
-		return time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-	}
 	tcs := []struct {
 		desc            string
 		webhook         Webhook

--- a/transport_test.go
+++ b/transport_test.go
@@ -183,14 +183,14 @@ func TestAddWebhookRequestDecoder(t *testing.T) {
 			InputPayload:       "{",
 			ExpectedErr:        errFailedWebhookUnmarshal,
 			Validator:          Validators{},
-			ExpectedStatusCode: 500,
+			ExpectedStatusCode: 400,
 		},
 		{
 			Description:        "Empty legacy case",
 			InputPayload:       "[]",
 			ExpectedErr:        errNoWebhooksInLegacyDecode,
 			Validator:          Validators{},
-			ExpectedStatusCode: 500,
+			ExpectedStatusCode: 400,
 		},
 		{
 			Description:  "Webhook validation Failure",
@@ -246,7 +246,7 @@ func TestAddWebhookRequestDecoder(t *testing.T) {
 					var s kithttp.StatusCoder
 					isCoder := errors.As(err, &s)
 					require.True(isCoder, "error isn't StatusCoder as expected")
-					require.Equal(http.StatusBadRequest, s.StatusCode())
+					require.Equal(tc.ExpectedStatusCode, s.StatusCode())
 				}
 
 			} else {

--- a/transport_test.go
+++ b/transport_test.go
@@ -196,6 +196,7 @@ func TestAddWebhookRequestDecoder(t *testing.T) {
 			Validator:    Validators{mockValidator()},
 			ExpectedErr:  errMockValidatorFail,
 		},
+		{
 			Description:  "Request Body Read Failure",
 			ExpectedErr:  errReadBodyFail,
 			ReadBodyFail: true,

--- a/transport_test.go
+++ b/transport_test.go
@@ -196,10 +196,9 @@ func TestAddWebhookRequestDecoder(t *testing.T) {
 			ExpectedErr:  errMockValidatorFail,
 		},
 		{
-			Description:  "Request Body Read Failure",
-			ExpectedErr:  errReadBodyFail,
-			ReadBodyFail: true,
-			Validator:    Validators{},
+			Description: "Request Body Read Failure",
+			ExpectedErr: errFailedWebhookUnmarshal,
+			Validator:   Validators{},
 		},
 	}
 


### PR DESCRIPTION
Changed addwebhookrequestdecoder to return 400 instead of 500 for bad request bodies and validation failures