### PR TITLE
added custom duration for webhook registration unmarshaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v0.3.9]
+- Updated wrp decoding for webhook registration to accept an int in seconds or a string of the form "5m". [#103](https://github.com/xmidt-org/ancla/pull/103)
 
 ## [v0.3.8]
 - Added measures and providemetrics func to metrics.go. [#98](https://github.com/xmidt-org/ancla/pull/98)
@@ -98,7 +100,8 @@ internalWebhooks. [#80](https://github.com/xmidt-org/ancla/pull/80)
 ## [v0.1.0]
 - Initial release
 
-[Unreleased]: https://github.com/xmidt-org/ancla/compare/v0.3.8...HEAD
+[Unreleased]: https://github.com/xmidt-org/ancla/compare/v0.3.9...HEAD
+[v0.3.9]: https://github.com/xmidt-org/ancla/compare/v0.3.8...v0.3.9
 [v0.3.8]: https://github.com/xmidt-org/ancla/compare/v0.3.7...v0.3.8
 [v0.3.7]: https://github.com/xmidt-org/ancla/compare/v0.3.6...v0.3.7
 [v0.3.6]: https://github.com/xmidt-org/ancla/compare/v0.3.5...v0.3.6

--- a/customDuration.go
+++ b/customDuration.go
@@ -18,6 +18,7 @@
 package ancla
 
 import (
+	"bytes"
 	"strconv"
 	"strings"
 	"time"
@@ -29,7 +30,7 @@ type InvalidDurationError struct {
 
 func (ide *InvalidDurationError) Error() string {
 	var o strings.Builder
-	o.WriteString("Invalid duration value: ")
+	o.WriteString("duration must be of type int or string (ex:'5m'); Invalid value: ")
 	o.WriteString(ide.Value)
 	return o.String()
 }
@@ -41,7 +42,11 @@ func (cd CustomDuration) String() string {
 }
 
 func (cd CustomDuration) MarshalJSON() ([]byte, error) {
-	return []byte(cd.String()), nil
+	d := bytes.NewBuffer(nil)
+	d.WriteByte('"')
+	d.WriteString(cd.String())
+	d.WriteByte('"')
+	return d.Bytes(), nil
 }
 
 func (cd *CustomDuration) UnmarshalJSON(b []byte) (err error) {

--- a/customDuration.go
+++ b/customDuration.go
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2022 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ancla
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+type InvalidDurationError struct {
+	Value string
+}
+
+func (ide *InvalidDurationError) Error() string {
+	var o strings.Builder
+	o.WriteString("Invalid duration value: ")
+	o.WriteString(ide.Value)
+	return o.String()
+}
+
+type CustomDuration time.Duration
+
+func (cd CustomDuration) String() string {
+	return time.Duration(cd).String()
+}
+
+func (cd CustomDuration) MarshalJSON() ([]byte, error) {
+	return []byte(cd.String()), nil
+}
+
+func (cd *CustomDuration) UnmarshalJSON(b []byte) (err error) {
+	if b[0] == '"' {
+		var d time.Duration
+		d, err = time.ParseDuration(string(b[1 : len(b)-1]))
+		if err == nil {
+			*cd = CustomDuration(d)
+			return
+		}
+	}
+
+	var d int64
+	d, err = strconv.ParseInt(string(b), 10, 64)
+	if err == nil {
+		*cd = CustomDuration(time.Duration(d) * time.Second)
+		return
+	}
+
+	err = &InvalidDurationError{
+		Value: string(b),
+	}
+
+	return
+}

--- a/customDuration_test.go
+++ b/customDuration_test.go
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2022 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ancla
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalJSON(t *testing.T) {
+	type test struct {
+		Duration CustomDuration
+	}
+	tests := []struct {
+		description      string
+		input            []byte
+		expectedDuration CustomDuration
+		errExpected      bool
+	}{
+		{
+			description:      "Int success",
+			input:            []byte(`{"duration":50}`),
+			expectedDuration: CustomDuration(50 * time.Second),
+		},
+		{
+			description:      "String success",
+			input:            []byte(`{"duration":"5m"}`),
+			expectedDuration: CustomDuration(5 * time.Minute),
+		},
+		{
+			description: "String failure",
+			input:       []byte(`{"duration":"2r"}`),
+			errExpected: true,
+		},
+		{
+			description: "Object failure",
+			input:       []byte(`{"duration":{"key":"val"}}`),
+			errExpected: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			cd := test{}
+			err := json.Unmarshal(tc.input, &cd)
+			assert.Equal(tc.expectedDuration, cd.Duration)
+			if !tc.errExpected {
+				assert.NoError(err)
+				return
+			}
+			assert.Error(err)
+		})
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	type test struct {
+		Duration CustomDuration
+	}
+	tests := []struct {
+		description    string
+		input          test
+		expectedOutput []byte
+		errExpected    bool
+	}{
+		{
+			description:    "Int success",
+			input:          test{Duration: CustomDuration(50 * time.Second)},
+			expectedOutput: []byte(`{"Duration":"50s"}`),
+		},
+		{
+			description:    "String success",
+			input:          test{Duration: CustomDuration(5 * time.Minute)},
+			expectedOutput: []byte(`{"Duration":"5m0s"}`),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			output, err := json.Marshal(tc.input)
+			assert.Equal(tc.expectedOutput, output)
+			if !tc.errExpected {
+				assert.NoError(err)
+				return
+			}
+			assert.Error(err)
+		})
+	}
+
+}

--- a/transport.go
+++ b/transport.go
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Comcast Cable Communications Management, LLC
+ * Copyright 2022 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,9 +108,9 @@ func addWebhookRequestDecoder(config transportConfig) kithttp.DecodeRequestFunc 
 		if err != nil {
 			return nil, err
 		}
-		var webhook Webhook
+		var wr WebhookRegistration
 
-		err = json.Unmarshal(requestPayload, &webhook)
+		err = json.Unmarshal(requestPayload, &wr)
 		if err != nil {
 			var e *json.UnmarshalTypeError
 			if errors.As(err, &e) {
@@ -119,6 +119,7 @@ func addWebhookRequestDecoder(config transportConfig) kithttp.DecodeRequestFunc 
 			return nil, &erraux.Error{Err: fmt.Errorf("%w: %v", errFailedWebhookUnmarshal, err), Code: http.StatusBadRequest}
 		}
 
+		webhook := wr.ToWebhook()
 		err = config.v.Validate(webhook)
 		if err != nil {
 			return nil, &erraux.Error{Err: err, Message: "failed webhook validation", Code: http.StatusBadRequest}

--- a/webhook.go
+++ b/webhook.go
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Comcast Cable Communications Management, LLC
+ * Copyright 2022 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,9 +62,47 @@ type Webhook struct {
 	Matcher MetadataMatcherConfig `json:"matcher,omitempty"`
 
 	// Duration describes how long the subscription lasts once added.
-	// Deprecated. User input is ignored and value is always 5m.
 	Duration time.Duration `json:"duration"`
 
 	// Until describes the time this subscription expires.
 	Until time.Time `json:"until"`
+}
+
+// WebhookRegistration is a special struct for unmarshaling a webhook as part of
+// a webhook registration request.  The only difference between this struct and
+// the Webhook struct is the Duration field.
+type WebhookRegistration struct {
+	// Address is the subscription request origin HTTP Address.
+	Address string `json:"registered_from_address"`
+
+	// Config contains data to inform how events are delivered.
+	Config DeliveryConfig `json:"config"`
+
+	// FailureURL is the URL used to notify subscribers when they've been cut off due to event overflow.
+	// Optional, set to "" to disable notifications.
+	FailureURL string `json:"failure_url"`
+
+	// Events is the list of regular expressions to match an event type against.
+	Events []string `json:"events"`
+
+	// Matcher type contains values to match against the metadata.
+	Matcher MetadataMatcherConfig `json:"matcher,omitempty"`
+
+	// Duration describes how long the subscription lasts once added.
+	Duration CustomDuration `json:"duration"`
+
+	// Until describes the time this subscription expires.
+	Until time.Time `json:"until"`
+}
+
+func (w WebhookRegistration) ToWebhook() Webhook {
+	return Webhook{
+		Address:    w.Address,
+		Config:     w.Config,
+		FailureURL: w.FailureURL,
+		Events:     w.Events,
+		Matcher:    w.Matcher,
+		Duration:   time.Duration(w.Duration),
+		Until:      w.Until,
+	}
 }


### PR DESCRIPTION
json unmarshal errors through the `addWebhookRequestDecoder`:
```
failed to JSON unmarshal webhook: config.content_type must be of type string
failed to JSON unmarshal webhook: duration must be of type int or string (ex:'5m'); Invalid value: "hehe"
```

part of https://github.com/xmidt-org/tr1d1um/issues/255