### PR TITLE
JWK Migration Release v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.3.10]
 - JWT Migration JWK Migration #113
   - update argus & bascule dependencies
 - replaced `ancla.Initialize` with `ancla.NewService`
@@ -104,7 +106,8 @@ internalWebhooks. [#80](https://github.com/xmidt-org/ancla/pull/80)
 ## [v0.1.0]
 - Initial release
 
-[Unreleased]: https://github.com/xmidt-org/ancla/compare/v0.3.9...HEAD
+[Unreleased]: https://github.com/xmidt-org/ancla/compare/v0.3.10...HEAD
+[v0.3.9]: https://github.com/xmidt-org/ancla/compare/v0.3.9...v0.3.10
 [v0.3.9]: https://github.com/xmidt-org/ancla/compare/v0.3.8...v0.3.9
 [v0.3.8]: https://github.com/xmidt-org/ancla/compare/v0.3.7...v0.3.8
 [v0.3.7]: https://github.com/xmidt-org/ancla/compare/v0.3.6...v0.3.7


### PR DESCRIPTION
What's included:

- JWT Migration JWK Migration #113
  - update argus & bascule dependencies
- replaced `ancla.Initialize` with `ancla.NewService`
- removed `Measures Measures` from `Config` and introduced `ListenerConfig`