### PR TITLE
updated unmarshaling logic

### DIFF
--- a/internalWebhook.go
+++ b/internalWebhook.go
@@ -93,6 +93,7 @@ func ItemToInternalWebhook(i model.Item) (Register, error) {
 	if err == nil {
 		return v1, nil
 	}
+
 	errs = errors.Join(errs, fmt.Errorf("RegistryV1 unmarshal error: %s", err))
 
 	return nil, fmt.Errorf("could not unmarshal data into either RegistryV1 or RegistryV2: %s", errs)

--- a/internalWebhook.go
+++ b/internalWebhook.go
@@ -82,18 +82,18 @@ func ItemToInternalWebhook(i model.Item) (Register, error) {
 		return nil, err
 	}
 
+	err = json.Unmarshal(encodedWebhook, &v2)
+	if err == nil && v2.Registration.CanonicalName != "" {
+		return v2, nil
+	} else if err != nil {
+		errs = errors.Join(errs, fmt.Errorf("RegistryV2 unmarshal error: %s", err))
+	}
+
 	err = json.Unmarshal(encodedWebhook, &v1)
 	if err == nil {
 		return v1, nil
 	}
-
 	errs = errors.Join(errs, fmt.Errorf("RegistryV1 unmarshal error: %s", err))
-	err = json.Unmarshal(encodedWebhook, &v2)
-	if err == nil {
-		return v2, nil
-	}
-
-	errs = errors.Join(errs, fmt.Errorf("RegistryV2 unmarshal error: %s", err))
 
 	return nil, fmt.Errorf("could not unmarshal data into either RegistryV1 or RegistryV2: %s", errs)
 }


### PR DESCRIPTION
What's Included:
- update to the ItemToInternalWebhook logic
- RegistryV2 was being unmarshaled into RegistryV1 due to having a handful of the same field names
- Checking canonical_name in v2 as it's not in v1 and it is a required field for V2