### PR TITLE
Normalize CI/CD workflows

### DIFF
--- a/.github/workflows/approve-dependabot.yml
+++ b/.github/workflows/approve-dependabot.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/dependabot-approver-template.yml@main
+    uses: xmidt-org/shared-go/.github/workflows/approve-dependabot.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit

--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -8,7 +8,8 @@ on:
     - cron: '0 12 * * *'
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: write
 
 jobs:
   release:

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,9 +11,12 @@ on:
     types:
       - opened
 
-permissions: {}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@aff0471aa7e2f96ddb059beb178f63747a7cc57e # v4.9.41
     secrets: inherit


### PR DESCRIPTION
## Summary

This PR normalizes the CI/CD workflows to match the xmidt-org ideal state as outlined in issue #305.

## Changes

- Renamed `dependabot-approver.yml` to `approve-dependabot.yml`
- Updated `approve-dependabot.yml` to reference `xmidt-org/shared-go/.github/workflows/approve-dependabot.yml`
- Updated `proj-xmidt-team.yml` to reference `xmidt-org/shared-go/.github/workflows/proj.yml`
- Pinned all workflow references to commit SHA `aff0471aa7e2f96ddb059beb178f63747a7cc57e` with version comment `v4.9.41`
- Added `contents: write` permission to `auto-releaser.yml`
- Added `contents: read`, `issues: write`, and `pull-requests: write` permissions to `proj-xmidt-team.yml`

Resolves #305