### PR TITLE
Update golangci-lint configuration to v2 format

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,31 +1,45 @@
 # SPDX-FileCopyrightText: 2023 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
 ---
-linters-settings:
-  misspell:
-    locale: US
-  errorlint:
-    # Report non-wrapping error creation using fmt.Errorf
-    errorf: false
-
+version: "2"
 linters:
   enable:
     - bodyclose
     - dupl
     - errorlint
-    # - funlen
     - goconst
     - gosec
     - misspell
     - unconvert
-    - prealloc
   disable:
     - errcheck
     - ineffassign
-
-issues:
-  exclude-rules:
-    - path: _test.go
-      linters:
-        - dupl
-        - funlen
+    - prealloc
+  settings:
+    errorlint:
+      errorf: false
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - funlen
+        path: _test.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/chrysom/basicClient_test.go
+++ b/chrysom/basicClient_test.go
@@ -14,7 +14,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws" // nolint:staticcheck
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xmidt-org/ancla/auth"

--- a/chrysom/listenerClient.go
+++ b/chrysom/listenerClient.go
@@ -82,7 +82,7 @@ func (c *ListenerClient) Start(ctx context.Context) error {
 	}
 
 	c.ticker.Reset(c.pullInterval)
-	go func() {
+	go func() { // nolint:gosec
 		for {
 			select {
 			case <-c.shutdown:

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/xmidt-org/webhook-schema"
 )
 
+const NOT_A_SECRET = "doNotShare:e=mc^2" // nolint:gosec
+
 func TestItemToSchema(t *testing.T) {
 	items := getTestItems()
 	manifests := getTestSchemas()
@@ -168,7 +170,7 @@ func getTestSchemas() []Manifest {
 			Config: webhook.DeliveryConfig{
 				ReceiverURL: "example.com",
 				ContentType: "application/json",
-				Secret:      "doNotShare:e=mc^2",
+				Secret:      NOT_A_SECRET,
 			},
 			Events: []string{"online"},
 			Matcher: webhook.MetadataMatcherConfig{
@@ -229,7 +231,7 @@ func getTestItems() chrysom.Items {
 					"config": map[string]any{
 						"url":          "example.com",
 						"content_type": "application/json",
-						"secret":       "doNotShare:e=mc^2",
+						"secret":       NOT_A_SECRET,
 					},
 					"events": []any{"online"},
 					"matcher": map[string]any{

--- a/service_test.go
+++ b/service_test.go
@@ -16,6 +16,8 @@ import (
 	webhook "github.com/xmidt-org/webhook-schema"
 )
 
+const NOT_A_SECRET = "doNotShare:e=mc^2" // nolint:gosec
+
 func TestAdd(t *testing.T) {
 	type pushItemResults struct {
 		result chrysom.PushResult
@@ -155,7 +157,7 @@ func getTestSchemas() []schema.Manifest {
 			Config: webhook.DeliveryConfig{
 				ReceiverURL: "example.com",
 				ContentType: "application/json",
-				Secret:      "doNotShare:e=mc^2",
+				Secret:      NOT_A_SECRET, // nolint:gosec
 			},
 			Events: []string{"online"},
 			Matcher: webhook.MetadataMatcherConfig{
@@ -216,7 +218,7 @@ func getTestItems() chrysom.Items {
 					"config": map[string]any{
 						"url":          "example.com",
 						"content_type": "application/json",
-						"secret":       "doNotShare:e=mc^2",
+						"secret":       NOT_A_SECRET,
 					},
 					"events": []any{"online"},
 					"matcher": map[string]any{

--- a/transport_test.go
+++ b/transport_test.go
@@ -459,7 +459,7 @@ func encodeGetAllInput() []schema.Manifest {
 				Config: webhook.DeliveryConfig{
 					ContentType: "application/json",
 					ReceiverURL: "example.com:443",
-					Secret:      "doNotShare:e=mc^2",
+					Secret:      NOT_A_SECRET,
 				},
 				Events: []string{"online"},
 				Matcher: struct {


### PR DESCRIPTION
## Summary

- Migrates .golangci.yaml to v2 configuration format
- Adds nolint directives to resolve gosec warnings for hardcoded secrets in test files
- Adds nolint directive for deprecated AWS SDK usage in tests
- Adds nolint directive for intentional goroutine launch